### PR TITLE
Get eleicoes ordinarias

### DIFF
--- a/divulgacandcontas-swagger.yml
+++ b/divulgacandcontas-swagger.yml
@@ -9,11 +9,66 @@ info:
 host: "divulgacandcontas.tse.jus.br"
 basePath: "/divulga/rest/v1"
 tags:
+- name: eleicoesOrdinarias
+  description: "Lista de eleições disponíveis para consulta"
 - name: eleicoes2020
   description: "Eleições municipais de 2020"
 schemes:
 - https
 paths:
+  /eleicao/ordinarias:
+    get:
+      tags:
+      - "eleicoesOrdinarias"
+      summary: "Eleições disponíveis"
+      description: "Lista eleições, por ano, disponível para consulta"
+      operationId: listaEleicoesOrdinarias
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            type: array
+            items:
+              type: object
+              properties: 
+                id: 
+                  type: integer
+                siglaUF: 
+                  type: string
+                  format: nullable
+                localidadeSgUe: 
+                  type: string
+                  format: nullable
+                ano: 
+                  type: integer
+                codigo: 
+                  type: string
+                  format: nullable
+                nomeEleicao: 
+                  type: string         
+                tipoEleicao:
+                  type: string
+                turno:
+                  type: string
+                  format: nullable
+                tipoAbragencia:
+                  type: string
+                dataEleicao:
+                  type: string
+                codSituacaoEleitoral:
+                  type: string
+                  format: nullable
+                descricaoSituacaoEleicao:
+                  type: string
+                  format: nullable
+                descricaoEleicao:
+                  type: string
+              
+        "404":
+          description: "não encontrado"
+
   /eleicao/listar/municipios/2030402020/{municipio}/cargos:
     get:
       tags:

--- a/divulgacandcontas-swagger.yml
+++ b/divulgacandcontas-swagger.yml
@@ -9,7 +9,7 @@ info:
 host: "divulgacandcontas.tse.jus.br"
 basePath: "/divulga/rest/v1"
 tags:
-- name: eleicoesOrdinarias
+- name: Eleições
   description: "Lista de eleições disponíveis para consulta"
 - name: eleicoes2020
   description: "Eleições municipais de 2020"
@@ -19,7 +19,7 @@ paths:
   /eleicao/ordinarias:
     get:
       tags:
-      - "eleicoesOrdinarias"
+      - "Eleições"
       summary: "Eleições disponíveis"
       description: "Lista eleições, por ano, disponível para consulta"
       operationId: listaEleicoesOrdinarias
@@ -68,7 +68,25 @@ paths:
               
         "404":
           description: "não encontrado"
-
+  /eleicao/anos-eleitorais:
+    get:
+      tags:
+      - "Eleições"
+      summary: "Anos eleitorais"
+      description: "Lista todos os anos eleitorais disponíveis para consulta"
+      operationId: listaAnosEleitorais
+      produces:
+      - "application/json"  
+      responses:
+        "202":
+          description: "OK"
+          schema:
+            type: array
+            items:
+              type: integer
+        
+        "404":
+            description: "não encontrado"
   /eleicao/listar/municipios/2030402020/{municipio}/cargos:
     get:
       tags:

--- a/examples/divulgacandcontas.http
+++ b/examples/divulgacandcontas.http
@@ -12,3 +12,7 @@ http://divulgacandcontas.tse.jus.br/divulga/rest/v1/candidatura/listar/2020/3515
 # Informações sobre um candidato específico
 https://divulgacandcontas.tse.jus.br/divulga/rest/v1/candidatura/buscar/2020/35157/2030402020/candidato/50000867342
 ###
+
+# Informações sobre as eleições disponíveis
+https://divulgacandcontas.tse.jus.br/divulga/rest/v1/eleicao/ordinarias
+###

--- a/examples/divulgacandcontas.http
+++ b/examples/divulgacandcontas.http
@@ -16,3 +16,7 @@ https://divulgacandcontas.tse.jus.br/divulga/rest/v1/candidatura/buscar/2020/351
 # Informações sobre as eleições disponíveis
 https://divulgacandcontas.tse.jus.br/divulga/rest/v1/eleicao/ordinarias
 ###
+
+# Informações sobre os anos eleitorais disponíveis
+https://divulgacandcontas.tse.jus.br/divulga/rest/v1/eleicao/anos-eleitorais
+###


### PR DESCRIPTION
Adicionando para a documentação duas chamadas que retornam informações gerais para uma eleição e necessárias para outras consultas.

Se aprovado essa primeira alteração pretendo atualizar o restante da documentação documentação fazer referências a essas variáveis por exemplo:
/eleicao/listar/municipios/{idEleicao}/{municipio}/cargos
/candidatura/listar/{anoEleitoral}/{municipio}/{idEleicao}/{cargo}/candidatos