### PR TITLE
fix: corrige erros estruturais, identação, semânticos e de validação

### DIFF
--- a/divulgacandcontas-swagger.yaml
+++ b/divulgacandcontas-swagger.yaml
@@ -1,8 +1,9 @@
 openapi: 3.0.1
 info:
   title: DivulgaCandContas
-  description: Documentação não oficial da API do sistema de divulgação de candidaturas
-    e contas ([DivulgaCandContas](http://divulgacandcontas.tse.jus.br/divulga/)) do
+  description: Documentação não oficial da API do sistema de divulgação de
+    candidaturas e contas
+    ([DivulgaCandContas](http://divulgacandcontas.tse.jus.br/divulga/)) do
     Tribunal Superior Eleitoral.
   termsOfService: http://www.tse.jus.br/transparencia/politica-de-privacidade-e-termos-de-uso
   contact:
@@ -12,58 +13,57 @@ externalDocs:
   description: Repositório de dados eleitorais
   url: https://www.tse.jus.br/eleicoes/estatisticas/repositorio-de-dados-eleitorais-1/repositorio-de-dados-eleitorais
 servers:
-- url: https://divulgacandcontas.tse.jus.br/divulga/rest/v1
+  - url: https://divulgacandcontas.tse.jus.br/divulga/rest/v1
 tags:
-- name: candidaturas
-  description: Candidaturas
-- name: contas
-  description: Informações sobre a prestação de contas
-- name: eleicoes
-  description: Eleições
-- name: eleicoes-suplementares
-  description: Eleições suplementares
+  - name: candidaturas
+    description: Candidaturas
+  - name: contas
+    description: Informações sobre a prestação de contas
+  - name: eleicoes
+    description: Eleições
+  - name: eleicoes-suplementares
+    description: Eleições suplementares
 paths:
-  /candidatura/listar/{ano}/{municipio}/{eleicao}/{cargo}/candidatos:
+  "/candidatura/listar/{ano}/{municipio}/{eleicao}/{cargo}/candidatos":
     get:
       tags:
-      - candidaturas
+        - candidaturas
       summary: Candidatos no município
       description: Lista de todos os candidatos nas eleições de 2020 no município
         especificado
       operationId: listaCandidatosPorMunicipio
       parameters:
-      - name: eleicao
-        in: path
-        description: >
-          Id da eleição
-
-          (ex.: 2030402020 para as eleições municipais de 2020)
-        required: true
-        schema:
-          type: integer
-        example: 2030402020
-      - name: ano
-        in: path
-        description: Ano
-        required: true
-        schema:
-          type: integer
-        example: 2020
-      - name: municipio
-        in: path
-        description: Código do município
-        required: true
-        schema:
-          type: integer
-        example: 35157
-      - name: cargo
-        in: path
-        description: Código do cargo
-        required: true
-        schema:
-          type: integer
+        - name: eleicao
+          in: path
+          description: |
+            Id da eleição
+            (ex.: 2030402020 para as eleições municipais de 2020)
+          required: true
+          schema:
+            type: integer
+          example: 2030402020
+        - name: ano
+          in: path
+          description: Ano
+          required: true
+          schema:
+            type: integer
+          example: 2020
+        - name: municipio
+          in: path
+          description: Código do município
+          required: true
+          schema:
+            type: integer
+          example: 35157
+        - name: cargo
+          in: path
+          description: Código do cargo
+          required: true
+          schema:
+            type: integer
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -79,56 +79,55 @@ paths:
                   candidatos:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Candidato'
-        404:
+                      $ref: "#/components/schemas/Candidato"
+        "404":
           description: não encontrado
           content: {}
-  /candidatura/buscar/{ano}/{municipio}/{eleicao}/candidato/{candidato}:
+  "/candidatura/buscar/{ano}/{municipio}/{eleicao}/candidato/{candidato}":
     get:
       tags:
-      - candidaturas
+        - candidaturas
       summary: Candidato
       description: Informações sobre o candidato
       operationId: consultaCandidato
       parameters:
-      - name: eleicao
-        in: path
-        description: >
-          Id da eleição
-
-          (ex.: 2030402020 para as eleições municipais de 2020)
-        required: true
-        schema:
-          type: integer
-        example: 2030402020
-      - name: ano
-        in: path
-        description: Ano
-        required: true
-        schema:
-          type: integer
-        example: 2020
-      - name: municipio
-        in: path
-        description: Código do município
-        required: true
-        schema:
-          type: integer
-        example: 35157
-      - name: candidato
-        in: path
-        description: Código do candidato
-        required: true
-        schema:
-          type: integer
-          format: int64
+        - name: eleicao
+          in: path
+          description: |
+            Id da eleição
+            (ex.: 2030402020 para as eleições municipais de 2020)
+          required: true
+          schema:
+            type: integer
+          example: 2030402020
+        - name: ano
+          in: path
+          description: Ano
+          required: true
+          schema:
+            type: integer
+          example: 2020
+        - name: municipio
+          in: path
+          description: Código do município
+          required: true
+          schema:
+            type: integer
+          example: 35157
+        - name: candidato
+          in: path
+          description: Código do candidato
+          required: true
+          schema:
+            type: integer
+            format: int64
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Candidato'
+                $ref: "#/components/schemas/Candidato"
   /eleicao/anos-eleitorais:
     get:
       tags:
@@ -137,7 +136,7 @@ paths:
       description: Lista de anos eleitorais
       operationId: anosEleitorais
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -145,23 +144,23 @@ paths:
                 type: array
                 items:
                   type: integer
-  /eleicao/estados/{ano}/ano:
+  "/eleicao/estados/{ano}/ano":
     get:
       tags:
-      - eleicoes-suplementares
+        - eleicoes-suplementares
       summary: Estados com eleições suplementares
       description: Lista de estados com eleições suplementares naquele ano
       operationId: eleicoesSuplementaresEstados
       parameters:
-      - name: ano
-        in: path
-        description: Ano
-        required: true
-        schema:
-          type: integer
-        example: 2020
+        - name: ano
+          in: path
+          description: Ano
+          required: true
+          schema:
+            type: integer
+          example: 2020
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -172,31 +171,31 @@ paths:
                   properties:
                     uf:
                       type: string
-        404:
+        "404":
           description: não encontrado
           content: {}
-  /eleicao/listar/municipios/{eleicao}/{municipio}/cargos:
+  "/eleicao/listar/municipios/{eleicao}/{municipio}/cargos":
     get:
       tags:
-      - eleicoes
+        - eleicoes
       summary: Cargos no município
       description: Lista de cargos em disputa no município
       operationId: listaCargosMunicipio
       parameters:
-      - name: eleicao
-        in: path
-        description: Id da eleição
-        required: true
-        schema:
-          type: integer
-      - name: municipio
-        in: path
-        description: Código do município
-        required: true
-        schema:
-          type: integer
+        - name: eleicao
+          in: path
+          description: Id da eleição
+          required: true
+          schema:
+            type: integer
+        - name: municipio
+          in: path
+          description: Código do município
+          required: true
+          schema:
+            type: integer
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -231,8 +230,8 @@ paths:
                   cargos:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Cargo'
-        404:
+                      $ref: "#/components/schemas/Cargo"
+        "404":
           description: não encontrado
           content: {}
   /eleicao/ordinarias:
@@ -243,7 +242,7 @@ paths:
       description: Lista eleições, por ano, disponível para consulta
       operationId: eleicoesOrdinarias
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -251,33 +250,33 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Eleicao"
-        404:
+        "404":
           description: não encontrado
           content: {}
-  /eleicao/suplementares/{ano}/{uf}:
+  "/eleicao/suplementares/{ano}/{uf}":
     get:
       tags:
-      - eleicoes-suplementares
+        - eleicoes-suplementares
       summary: Eleições suplementares
       description: Lista de eleições suplementares no estado naquele ano
       operationId: eleicoesSuplementaresPorUF
       parameters:
-      - name: ano
-        in: path
-        description: Ano
-        required: true
-        schema:
-          type: integer
-        example: 2020
-      - name: uf
-        in: path
-        description: Sigla da unidade federativa
-        required: true
-        schema:
-          type: string
-        example: AL
+        - name: ano
+          in: path
+          description: Ano
+          required: true
+          schema:
+            type: integer
+          example: 2020
+        - name: uf
+          in: path
+          description: Sigla da unidade federativa
+          required: true
+          schema:
+            type: string
+          example: AL
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -285,56 +284,55 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Eleicao"
-        404:
+        "404":
           description: não encontrado
           content: {}
-  /prestador/consulta/{eleicao}/{ano}/{municipio}/{cargo}/90/90/{candidato}:
+  "/prestador/consulta/{eleicao}/{ano}/{municipio}/{cargo}/90/90/{candidato}":
     get:
       tags:
-      - contas
+        - contas
       summary: Prestador
       description: Informações sobre o prestador de contas
       operationId: consultaPrestador
       parameters:
-      - name: eleicao
-        in: path
-        description: >
-          Id da eleição
-
-          (ex.: 2030402020 para as eleições municipais de 2020)
-        required: true
-        schema:
-          type: integer
-        example: 2030402020
-      - name: ano
-        in: path
-        description: Ano
-        required: true
-        schema:
-          type: integer
-        example: 2020
-      - name: municipio
-        in: path
-        description: Código do município
-        required: true
-        schema:
-          type: integer
-        example: 35157
-      - name: cargo
-        in: path
-        description: Código do cargo
-        required: true
-        schema:
-          type: integer
-      - name: candidato
-        in: path
-        description: Código do candidato
-        required: true
-        schema:
-          type: integer
-          format: int64
+        - name: eleicao
+          in: path
+          description: |
+            Id da eleição
+            (ex.: 2030402020 para as eleições municipais de 2020)
+          required: true
+          schema:
+            type: integer
+          example: 2030402020
+        - name: ano
+          in: path
+          description: Ano
+          required: true
+          schema:
+            type: integer
+          example: 2020
+        - name: municipio
+          in: path
+          description: Código do município
+          required: true
+          schema:
+            type: integer
+          example: 35157
+        - name: cargo
+          in: path
+          description: Código do cargo
+          required: true
+          schema:
+            type: integer
+        - name: candidato
+          in: path
+          description: Código do candidato
+          required: true
+          schema:
+            type: integer
+            format: int64
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -675,7 +673,7 @@ paths:
                   sobraEstimavel:
                     type: string
                     format: nullable
-        404:
+        "404":
           description: não encontrado
           content: {}
 components:
@@ -784,7 +782,7 @@ components:
           type: string
           format: nullable
         cargo:
-          $ref: '#/components/schemas/Cargo'
+          $ref: "#/components/schemas/Cargo"
         bens:
           type: array
           items:
@@ -1084,4 +1082,4 @@ components:
           type: string
           format: nullable
         descricaoEleicao:
-              type: string
+          type: string

--- a/divulgacandcontas-swagger.yaml
+++ b/divulgacandcontas-swagger.yaml
@@ -151,7 +151,7 @@ paths:
       - eleicoes-suplementares
       summary: Estados com eleições suplementares
       description: Lista de estados com eleições suplementares naquele ano
-      operationId: eleicoes_suplementares_estados
+      operationId: eleicoesSuplementaresEstados
       parameters:
       - name: ano
         in: path
@@ -168,8 +168,10 @@ paths:
               schema:
                 type: array
                 items:
-                  uf:
-                    type: string
+                  type: object
+                  properties:
+                    uf:
+                      type: string
         404:
           description: não encontrado
           content: {}
@@ -248,7 +250,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Eleição"
+                  $ref: "#/components/schemas/Eleicao"
         404:
           description: não encontrado
           content: {}
@@ -258,7 +260,7 @@ paths:
       - eleicoes-suplementares
       summary: Eleições suplementares
       description: Lista de eleições suplementares no estado naquele ano
-      operationId: eleicoes_suplementares_estados
+      operationId: eleicoesSuplementaresPorUF
       parameters:
       - name: ano
         in: path
@@ -282,7 +284,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Eleição"
+                  $ref: "#/components/schemas/Eleicao"
         404:
           description: não encontrado
           content: {}
@@ -1048,7 +1050,7 @@ components:
         contagem:
           type: integer
           format: int32
-    Eleição:
+    Eleicao:
       type: object
       properties:
         id:


### PR DESCRIPTION
# Atual

O swagger estava reclamando um pouco dos caracteres especiais e métodos com mesmo nome.

<img width="1245" height="546" alt="image" src="https://github.com/user-attachments/assets/529fecb2-4ab4-43aa-bb53-7c1b768ca0e4" />

> `Em`: https://forge.etsi.org/swagger/editor/


<strong>Structural error</strong> at paths./eleicao/estados/{ano}/ano.get.responses.200.content.application/json.schema.items
should NOT have additional properties
additionalProperty: uf
_Jump to line 170_

<strong>Semantic error</strong> at paths./eleicao/ordinarias.get.responses.200.content.application/json.schema.items.$ref
$ref values must be RFC3986-compliant percent-encoded URIs
_Jump to line 251_

<strong>Semantic error</strong> at paths./eleicao/suplementares/{ano}/{uf}.get.operationId
Operations must have unique operationIds.
_Jump to line 261_

<strong>Semantic error</strong> at paths./eleicao/suplementares/{ano}/{uf}.get.responses.200.content.application/json.schema.items.$ref
$ref values must be RFC3986-compliant percent-encoded URIs
_Jump to line 285_

<strong>Semantic error</strong> at components.schemas.Eleição
Component names can only contain the characters A-Z a-z 0-9 - . _
_Jump to line 1051_


<img width="943" height="75" alt="image" src="https://github.com/user-attachments/assets/4512c51c-aa1f-4451-a373-75c221a79b6e" />

> `Em`: https://editor.swagger.io/


---

# Correções

- Resolve erro estrutural em `/eleicao/estados/{ano}/ano` definindo corretamente `items` como um objeto com a propriedade `uf`, em vez de passar a propriedade diretamente no array.
- Renomeia o schema `Eleição` para `Eleicao` em `components.schemas`,  pois nomes de componentes suportam apenas caracteres A-Z a-z 0-9 - . _
- Corrige os apontamentos de `$ref` em `/eleicao/ordinarias` e  `/eleicao/suplementares/{ano}/{uf}` para usar `#/components/schemas/Eleicao`, resolvendo o erro de URI não compatível com a RFC3986 (remoção de caracteres especiais).
- Altera o `operationId` da rota `/eleicao/suplementares/{ano}/{uf}`  para garantir unicidade, resolvendo o conflito com a rota `/eleicao/estados/{ano}/ano`  que utilizava o mesmo id (`eleicoes_suplementares_estados`).